### PR TITLE
Fix type spec for close_position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `ecto` from 3.12.2 to 3.13.3
 - Updated `dialyxir` from 1.4.3 to 1.4.6
 
+### Fixed
+- Fixed type for `Positions.close_position/5`, `body` was incorrectly marked as `String.t()` in the spec; updated to `map()`
+
 ## [0.1.0] - 2025-10-18
 
 ### Changed

--- a/config.yml
+++ b/config.yml
@@ -333,7 +333,7 @@ interfaces:
           - name: "instrument"
             type: "string"
           - name: "body"
-            type: "string"
+            type: "map"
   - module_name: "Transactions"
     description: "Interface for Oanda transactions."
     docs_link: "https://developer.oanda.com/rest-live-v20/transaction-ep/"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected API specification for closing positions: the body parameter now correctly accepts map objects instead of strings, ensuring proper validation and payload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->