### PR TITLE
fix: removed replaced_by_order_id requirement in order fill transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Fixed `OrderCancelTransaction` model, `replaced_by_order_id` is not always included in API response.
+
 ## [0.2.2] - 2026-03-02
 
 ### Added

--- a/lib/models/definitions/transaction/order_cancel_transaction.ex
+++ b/lib/models/definitions/transaction/order_cancel_transaction.ex
@@ -50,8 +50,7 @@ defmodule ExOanda.OrderCancelTransaction do
       :request_id,
       :type,
       :order_id,
-      :reason,
-      :replaced_by_order_id
+      :reason
     ])
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExOanda.MixProject do
   def project do
     [
       app: :ex_oanda,
-      version: "0.2.2",
+      version: "0.2.3",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the `replaced_by_order_id` field was not always included in API responses as expected.

* **Version**
  * Updated to v0.2.3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholasbair/ex_oanda/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->